### PR TITLE
Tune markdown separator and add mermaid

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@marp-team/marp-core": "^3.9.0",
     "hono": "^3.8.1",
     "reveal.js": "^5.0.1",
+    "reveal.js-mermaid-plugin": "^2.0.0",
     "tslib": "^2"
   },
   "engines": {

--- a/pages/markdown.tsx
+++ b/pages/markdown.tsx
@@ -42,10 +42,17 @@ const header = (
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/dist/theme/black.css"
-      integrity="sha256-u7b1ew+/UCV5esol+6xydfpMhXWOxKlNzz3+H+UQ6H8="
+      href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/dist/theme/simple.css"
+      integrity="sha256-BYbhkIKkrDAzklCmlvqhvE11+kJhqINHgrGzQOAEdMg="
       crossorigin="anonymous"
     />
+
+    {/*<link*/}
+    {/*  rel="stylesheet"*/}
+    {/*  href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/dist/theme/black.css"*/}
+    {/*  integrity="sha256-u7b1ew+/UCV5esol+6xydfpMhXWOxKlNzz3+H+UQ6H8="*/}
+    {/*  crossorigin="anonymous"*/}
+    {/*/>*/}
   </Fragment>
 );
 export function MarkdownPage() {

--- a/pages/markdown.tsx
+++ b/pages/markdown.tsx
@@ -26,6 +26,61 @@ export function MarkdownPage2() {
   );
 }
 
+const themes = {
+  white: (
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/dist/theme/white.css"
+      integrity="sha256-WqOk5DDwjhWKLU+Yp/xxhPXvNlWUK7U7qGhj/JNqLPA="
+      crossorigin="anonymous"
+    />
+  ),
+  simple: (
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/dist/theme/simple.css"
+      integrity="sha256-BYbhkIKkrDAzklCmlvqhvE11+kJhqINHgrGzQOAEdMg="
+      crossorigin="anonymous"
+    />
+  ),
+  black: (
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/dist/theme/black.css"
+      integrity="sha256-u7b1ew+/UCV5esol+6xydfpMhXWOxKlNzz3+H+UQ6H8="
+      crossorigin="anonymous"
+    />
+  ),
+} as const;
+
+const code = {
+  monokai: (
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/plugin/highlight/monokai.css"
+      integrity="sha256-UE5RMUFE8/gycVXcaVAroQsaSZGuTMP6cAhs8VVGWZk="
+      crossorigin="anonymous"
+    />
+  ),
+  zenburn: (
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/plugin/highlight/zenburn.css"
+      integrity="sha256-uhRpp9AZTJyimq9K0zQf/uW/u1g/IvBiDiXpGpqEZDE="
+      crossorigin="anonymous"
+    />
+  ),
+
+  docco: (
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/docco.min.css"
+      integrity="sha256-f00Sea6GJsgCmYG/ihG88J4oJkrA1MpWWVm0EZPCXyw="
+      crossorigin="anonymous"
+    />
+  ),
+} as const;
+
 const header = (
   <Fragment>
     <link
@@ -40,24 +95,19 @@ const header = (
       integrity="sha256-kn0GsHm3VJbbHu3LH5BQYg//SYDTkhbrHsseRTZgTz0="
       crossorigin="anonymous"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/dist/theme/simple.css"
-      integrity="sha256-BYbhkIKkrDAzklCmlvqhvE11+kJhqINHgrGzQOAEdMg="
+    {themes.simple}
+    {code.docco}
+    {/*(IDK how to load this in bundler)*/}
+    <script
+      src="https://cdn.jsdelivr.net/npm/reveal.js-mermaid-plugin@2.0.0/plugin/mermaid/mermaid.js"
+      integrity="sha256-A9u8JpiMonZpMPHSm1jLJOWwtRfCOaqHKlQjjbZXwXQ="
       crossorigin="anonymous"
     />
-
-    {/*<link*/}
-    {/*  rel="stylesheet"*/}
-    {/*  href="https://cdn.jsdelivr.net/npm/reveal.js@5.0.1/dist/theme/black.css"*/}
-    {/*  integrity="sha256-u7b1ew+/UCV5esol+6xydfpMhXWOxKlNzz3+H+UQ6H8="*/}
-    {/*  crossorigin="anonymous"*/}
-    {/*/>*/}
   </Fragment>
 );
 export function MarkdownPage() {
   const text = `
-  
+
 ## Section 1
 
 Slide 1
@@ -79,7 +129,6 @@ Slide 3
     `.trim();
 
   const options = {
-    'data-markdown': '',
     'data-separator': '^\n---\n$',
     'data-separator-vertical': '^\n--\n$',
   };
@@ -87,7 +136,7 @@ Slide 3
     <DefaultHtml header={header}>
       <div class="reveal" hidden>
         <div class="slides">
-          <section {...options}>
+          <section data-markdown="" {...options}>
             <script id="reveal-slide-source" type="text/template">
               {text}
             </script>

--- a/pages/markdown.tsx
+++ b/pages/markdown.tsx
@@ -57,20 +57,37 @@ const header = (
 );
 export function MarkdownPage() {
   const text = `
-## Demo 1
+  
+## Section 1
+
 Slide 1
+
 ---
-## Demo 1
-Slide 2
+
+## Section 2
+Slide 2-1
+
+--
+
+## Section 2
+Slide 2-2
+
 ---
+
 ## Demo 1
 Slide 3
     `.trim();
+
+  const options = {
+    'data-markdown': '',
+    'data-separator': '^\n---\n$',
+    'data-separator-vertical': '^\n--\n$',
+  };
   return (
     <DefaultHtml header={header}>
       <div class="reveal" hidden>
         <div class="slides">
-          <section data-markdown="">
+          <section {...options}>
             <script id="reveal-slide-source" type="text/template">
               {text}
             </script>

--- a/src/markdown-reveal.ts
+++ b/src/markdown-reveal.ts
@@ -3,15 +3,17 @@ import RevealMarkdown from 'reveal.js/plugin/markdown/markdown';
 import RevealHighlight from 'reveal.js/plugin/highlight/highlight';
 import RevealSearch from 'reveal.js/plugin/search/search';
 import RevealMath from 'reveal.js/plugin/math/math';
+// @ts-ignore
+import RevealMermaid from 'reveal.js-mermaid-plugin/plugin/mermaid/mermaid';
 import { allComponents, provideFluentDesignSystem } from '@fluentui/web-components';
 import { wait } from '@jokester/ts-commonutil/lib/concurrency/timing';
 
 provideFluentDesignSystem().register(allComponents);
 
-async function tryReveal2() {
-  const slides = document.querySelector('div.reveal') as HTMLDivElement;
-  const f = document.querySelector('form#markdown-form') as HTMLFormElement;
+const slides = document.querySelector('div.reveal') as HTMLDivElement;
+const f = document.querySelector('form#markdown-form') as HTMLFormElement;
 
+async function initControl() {
   const startButton = f.querySelector('*[type=submit]') as HTMLButtonElement;
   startButton.textContent = 'Start';
   startButton.disabled = false;
@@ -25,25 +27,30 @@ async function tryReveal2() {
     const slideSource = file0 ? await file0.text() : textArea.value;
 
     wait(0.1e3).then(() => {
-      f.remove();
-      slides.hidden = false;
-      tryReveal(slideSource);
+      startReveal(slideSource);
     });
   };
 }
 
-async function tryReveal(text: string) {
+async function DEBUG_example() {
+  const md = await fetch('/example.md').then((r) => r.text());
+  await startReveal(md);
+}
+
+async function startReveal(text: string) {
+  f.remove();
+  slides.hidden = false;
   const revealSlideSource = document.querySelector('script#reveal-slide-source') as HTMLScriptElement;
   revealSlideSource.textContent = text;
   await Reveal.initialize({
     controls: true,
     progress: true,
-    history: false,
+    history: true,
     slideNumber: true,
-    hash: false,
+    hash: true,
     center: true,
-    plugins: [RevealMarkdown, RevealHighlight, RevealSearch, RevealMath],
+    plugins: [RevealMarkdown, RevealHighlight, RevealSearch, RevealMath, RevealMermaid],
   });
 }
 
-setTimeout(tryReveal2, 1000);
+setTimeout(initControl);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,6 +3013,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+reveal.js-mermaid-plugin@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reveal.js-mermaid-plugin/-/reveal.js-mermaid-plugin-2.0.0.tgz#47744405650805434819db566f3ea662a7f99db3"
+  integrity sha512-PfuolEBIOqlQtlPv0dCm1QjHrV7xpX69Kel5xiRlsttfPn/LY5yVZWKe0qhSDL3wBYumCHgFkB0LScqwSAOYRg==
+
 reveal.js@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/reveal.js/-/reveal.js-5.0.1.tgz#c489425bbc42c2160b1198584113e9419b43a593"


### PR DESCRIPTION
closes https://github.com/jokester/slides.ihate.work/issues/1

- it was not meaningful to steal from https://github.com/evilz/vscode-reveal , the plugin keeps its own copy of dependencies in git repo , and is not using reveal.js options directly
  - instead tuned markdown slide separators

- add https://github.com/zjffun/reveal.js-mermaid-plugin for mermaid