### PR TITLE
wrap reveal.js in iframe

### DIFF
--- a/pages/_internal/reveal-player.tsx
+++ b/pages/_internal/reveal-player.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router';
+import { useAsyncEffect } from '@jokester/ts-commonutil/lib/react/hook/use-async-effect';
+import { useState } from 'react';
+import { extractErrorMessage } from '../../src/utils';
+import { RevealSlidePlayer } from '../../src/player/reveal-slide-player';
+
+export default function RevealPlayerPage() {
+  const router = useRouter();
+  const [slideSrc, setSlideSrc] = useState('');
+  const [error, setError] = useState('');
+
+  useAsyncEffect(async () => {
+    if (router.isReady) {
+      const query = router.query as { url: string };
+      try {
+        const text = await fetch(query.url).then((res) => res.text());
+        setSlideSrc(text);
+      } catch (e: any) {
+        console.error(e);
+        setError(extractErrorMessage(e));
+      }
+    }
+  }, [router, router.isReady]);
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (slideSrc) {
+    return <RevealSlidePlayer src={slideSrc} />;
+  }
+  return null;
+}

--- a/src/markdown/markdown-form.tsx
+++ b/src/markdown/markdown-form.tsx
@@ -54,7 +54,6 @@ async function readFormValue(f: HTMLFormElement): Promise<string> {
 export function MarkdownForm(props: PropsWithChildren<MarkdownFormProps>) {
   const [loaded, setLoaded] = useState(true);
   useAsyncEffect(async (running) => {
-    await import('./markdown-reveal');
     if (running.current) {
       setLoaded(true);
     }

--- a/src/pages/markdown.tsx
+++ b/src/pages/markdown.tsx
@@ -1,9 +1,9 @@
 import { Fragment, useState } from 'react';
 import { MarkdownForm } from '../markdown/markdown-form';
-import { MarkdownSlides } from '../markdown/markdown-slides';
 import { DefaultMeta } from '../components/meta/default-meta';
 import { useSearchParams } from 'next/navigation';
 import { useAsyncEffect } from '@jokester/ts-commonutil/lib/react/hook/use-async-effect';
+import { RevealSlideWrapper } from '../player/reveal-slide-wrapper';
 
 function PageHeader() {
   return (
@@ -104,7 +104,7 @@ export function MarkdownPage() {
     if (markdownUrl) {
       setText(await fetchText(markdownUrl));
     }
-  });
+  }, [markdownUrl]);
 
   if (!text) {
     return (
@@ -124,7 +124,7 @@ export function MarkdownPage() {
   return (
     <>
       <DefaultMeta title="slides.ihate.work" />
-      <MarkdownSlides text={text} />
+      <RevealSlideWrapper onDestroy={() => setText('')} text={text} />
     </>
   );
 }

--- a/src/player/reveal-init.ts
+++ b/src/player/reveal-init.ts
@@ -1,17 +1,12 @@
-// @ts-ignore
 import Reveal from 'reveal.js';
-// @ts-ignore
 import RevealMarkdown from 'reveal.js/plugin/markdown/markdown';
-// @ts-ignore
 import RevealHighlight from 'reveal.js/plugin/highlight/highlight';
-// @ts-ignore
 import RevealSearch from 'reveal.js/plugin/search/search';
-// @ts-ignore
-import RevealMath from 'reveal.js/plugin/math/math';
+import { MathJax3 } from 'reveal.js/plugin/math/math';
 // @ts-ignore
 import RevealMermaid from 'reveal.js-mermaid-plugin/plugin/mermaid/mermaid';
 
-export async function startReveal() {
+export async function startReveal(): Promise<Reveal.Api> {
   // mermaid plugin expects this
   (window as any).Reveal ??= Reveal;
   await Reveal.initialize({
@@ -21,6 +16,7 @@ export async function startReveal() {
     slideNumber: true,
     hash: true,
     center: true,
-    plugins: [RevealMarkdown, RevealHighlight, RevealSearch, RevealMath.MathJax3, RevealMermaid],
+    plugins: [RevealMarkdown, RevealHighlight, RevealSearch, MathJax3, RevealMermaid],
   });
+  return Reveal;
 }

--- a/src/player/reveal-slide-player.tsx
+++ b/src/player/reveal-slide-player.tsx
@@ -1,20 +1,25 @@
 import { wait } from '@jokester/ts-commonutil/lib/concurrency/timing';
 import { PropsWithChildren, useEffect } from 'react';
 import { useAsyncEffect } from '@jokester/ts-commonutil/lib/react/hook/use-async-effect';
+import debug from 'debug';
+
+const logger = debug('src:markdown:markdown-slides');
 
 export interface MarkdownSlideProps {
-  text: string;
+  src: string;
+  onDestroy?(): void;
 }
 
-export function MarkdownSlides(props: PropsWithChildren<MarkdownSlideProps>) {
+export function RevealSlidePlayer(props: PropsWithChildren<MarkdownSlideProps>) {
   useAsyncEffect(async (running, released) => {
-    const { startReveal } = await import('./markdown-reveal');
+    const { startReveal } = await import('./reveal-init');
 
     await wait(0.1e3);
     if (!running.current) {
       return;
     }
-    await startReveal();
+    const api = await startReveal();
+    logger('reveal initialized', api);
   }, []);
   const options = {
     'data-separator': '^\n---\n$',
@@ -25,7 +30,7 @@ export function MarkdownSlides(props: PropsWithChildren<MarkdownSlideProps>) {
     <div className="reveal">
       <div className="slides">
         <section data-markdown="" {...options}>
-          <script type="text/template">{props.text}</script>
+          <script type="text/template">{props.src}</script>
         </section>
       </div>
     </div>

--- a/src/player/reveal-slide-wrapper.tsx
+++ b/src/player/reveal-slide-wrapper.tsx
@@ -1,0 +1,98 @@
+import { useAsyncEffect } from '@jokester/ts-commonutil/lib/react/hook/use-async-effect';
+import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { wait } from '@jokester/ts-commonutil/lib/concurrency/timing';
+import { filter, fromEvent, merge, scan, tap } from 'rxjs';
+import debug from 'debug';
+import { Button } from '@mui/material';
+
+const logger = debug('src:player:reveal-slide-wrapper');
+
+interface RevealSlideWrapperProps {
+  text: string;
+  onDestroy?(): void;
+}
+
+function useEscDoubleclick({ onDestroy }: RevealSlideWrapperProps, iframeRef: RefObject<HTMLIFrameElement>): void {
+  useAsyncEffect(
+    async (running, released) => {
+      if (!onDestroy) {
+        return;
+      }
+      while (!iframeRef.current) {
+        await wait(0.1e3);
+        if (!running.current) {
+          return;
+        }
+      }
+      const $keyup1 = fromEvent<KeyboardEvent>(document, 'keyup');
+      const $keyup2 = fromEvent<KeyboardEvent>(iframeRef.current.contentDocument!, 'keyup');
+
+      const $escape = merge($keyup1, $keyup2).pipe(
+        tap((ev) => {
+          logger('key pressed', ev);
+        }),
+        filter((e) => e.key === 'Escape'),
+        scan((acc, _) => acc + 1, 0),
+        tap((value) => {
+          logger('escape key pressed %d times', value);
+        }),
+      );
+
+      const s = $escape.subscribe((count) => {
+        if (count >= 2) {
+          onDestroy();
+        }
+      });
+      logger('useEscDoubleclick', s);
+
+      released.then(() => s.unsubscribe());
+    },
+    [iframeRef, onDestroy],
+  );
+}
+
+export function RevealSlideWrapper(props: RevealSlideWrapperProps) {
+  const [assetUrl, setAssetUrl] = useState('');
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  useEscDoubleclick(props, iframeRef);
+
+  useAsyncEffect(
+    async (running) => {
+      if (props.text) {
+        const blob = new Blob([props.text], { type: 'text/markdown' });
+        // FIXME: free this allocation
+        const url = URL.createObjectURL(blob);
+        setAssetUrl(url);
+
+        await wait(5e3);
+        if (!running.current) {
+          return;
+        }
+        // props.onDestroy?.();
+      }
+    },
+    [props.text],
+  );
+
+  const iframeUrl = useMemo(() => {
+    if (!assetUrl) {
+      return '';
+    }
+    return `/_internal/reveal-player?url=${encodeURIComponent(assetUrl)}`;
+  }, [assetUrl]);
+
+  if (iframeUrl) {
+    return (
+      <>
+        <div className="absolute left-0 top-0 p-4 hidden hover:inline-block">
+          <Button type="button" onClick={props.onDestroy}>
+            Close
+          </Button>
+        </div>
+        <iframe ref={iframeRef} key={iframeUrl} style={{ width: '100vw', height: '100vh' }} src={iframeUrl} />
+      </>
+    );
+  }
+
+  return null;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,9 @@
+export function extractErrorMessage(e: any): string {
+  if (e instanceof Error) {
+    return e.message;
+  }
+  if (typeof e === 'string') {
+    return e;
+  }
+  return e?.message ?? e?.code ?? 'error occured';
+}


### PR DESCRIPTION
because it's dam hard to restore to a state before `Reveal.initialize()` 🤦🏽 

fixes https://github.com/jokester/slides.ihate.work/issues/11